### PR TITLE
Replace collision callback system with event-driven system.

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -2,9 +2,7 @@ name: build-ubuntu
 
 on:
   push:
-    branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 jobs:
   build:

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_policy(SET CMP0069 NEW)
 
 project(MxPhysDemo)
 
+find_package(SDL2 REQUIRED)
+
 add_executable(mxphysdemo "${CMAKE_CURRENT_SOURCE_DIR}/demo.cpp")
 set_property(GLOBAL PROPERTY CXX_STANDARD_REQUIRED 20)
 set_property(GLOBAL PROPERTY CXX_STANDARD 20)
@@ -18,4 +20,4 @@ if(result)
 endif()
 
 target_include_directories(mxphysdemo PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include")
-target_link_libraries(mxphysdemo PUBLIC SDL2 MxPhysLib)
+target_link_libraries(mxphysdemo PUBLIC SDL2::SDL2 MxPhysLib)

--- a/demo/demo.cpp
+++ b/demo/demo.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 
 #include <random>
-#include <SDL2/SDL.h>
+#include <SDL.h>
 #include <chrono>
 
 #include "mxphys/polygon.h"

--- a/include/mxphys/body.h
+++ b/include/mxphys/body.h
@@ -14,6 +14,8 @@ namespace mxphys {
 class body {
 private:
 
+    static uint64_t id_next;
+
     convex_polygon shape;
     // position of center of mass
     affine_2d position;
@@ -26,16 +28,17 @@ private:
     vec2 velocity;
     double angular_frequency;
 
+    const uint64_t id;
+
 public:
     body() = delete;
     body(const convex_polygon& _shape, const affine_2d& _pos, double _mass, double _moment_of_inertia, double _elasticity)
-    : shape(_shape), position(_pos), mass(_mass), moment_of_inertia(_moment_of_inertia), elasticity(_elasticity),
-      velocity{0.0, 0.0}, angular_frequency(0.0) {}
+      : shape(_shape), position(_pos), mass(_mass), moment_of_inertia(_moment_of_inertia), elasticity(_elasticity),
+        velocity{0.0, 0.0}, angular_frequency(0.0), id(id_next) {
+        ++id_next;
+    }
 
     void get_contact_points(body& other, std::vector<contact_point>& out_contact_points);
-    void get_contact_points(body & other, std::vector<contact_point>& out_contact_points,
-                            std::initializer_list<std::function<void(contact_point*)>> precallbacks,
-                            std::initializer_list<std::function<void(contact_point*)>> postcallbacks);
     vec2 velocityAt(vec2 point) const {
         auto p = point - position.shift;
         return velocity + angular_frequency * (mat2{0,-1,1,0} * p);
@@ -50,6 +53,11 @@ public:
     const convex_polygon& getShape() const {
         return shape;
     }
+
+    void setShape(const convex_polygon& new_shape) {
+        shape = new_shape;
+    }
+
     auto getTranslatedPoints() const {
         return std::views::transform(shape.getPoints(), [this](vec2 v) {return position(v);});
     }
@@ -94,6 +102,10 @@ public:
     }
     void setElasticity(double e) {
         elasticity = e;
+    }
+
+    uint64_t getID() const {
+        return id;
     }
 
     double kineticEnergy() const {

--- a/include/mxphys/event/collision_event.h
+++ b/include/mxphys/event/collision_event.h
@@ -1,0 +1,44 @@
+#ifndef MXPHYS_EVENT_COLLISION_EVENT_H
+#define MXPHYS_EVENT_COLLISION_EVENT_H
+
+#include <utility>
+
+#include "mxphys/types.h"
+#include "mxphys/forces.h"
+
+namespace mxphys::event {
+
+struct collision_event : public event_data {
+    std::pair<uint64_t, uint64_t> ids;
+    std::pair<double, double> masses;
+    std::pair<double, double> moments_of_inertia;
+    std::pair<vec2, vec2> vs_init;
+    std::pair<vec2, vec2> vs_final;
+    std::pair<double, double> afs_init;
+    std::pair<double, double> afs_final;
+    double impulse_mag;
+    vec2 point;
+    vec2 normal;
+    double restitution;
+    collision_event(
+        auto _ids,
+        auto _masses,
+        auto _moments_of_inertia,
+        auto _vs_init,
+        auto _vs_final,
+        auto _afs_init,
+        auto _afs_final,
+        auto _impulse_mag,
+        auto _point,
+        auto _normal,
+        auto _rest
+    ) : ids(_ids), masses(_masses), moments_of_inertia(_moments_of_inertia),
+        vs_init(_vs_init), vs_final(_vs_final), afs_init(_afs_init),afs_final(_afs_final),
+        impulse_mag(_impulse_mag), point(_point), normal(_normal), restitution(_rest) {}
+};
+
+}
+
+#endif
+
+

--- a/include/mxphys/event/event_data.h
+++ b/include/mxphys/event/event_data.h
@@ -1,0 +1,14 @@
+#ifndef MXPHYS_EVENT_EVENT_DATA_H
+#define MXPHYS_EVENT_EVENT_DATA_H
+
+namespace mxphys::event {
+
+struct event_data {
+
+};
+
+}
+
+#endif
+
+

--- a/include/mxphys/event/event_types.h
+++ b/include/mxphys/event/event_types.h
@@ -1,0 +1,12 @@
+#ifndef MXPHYS_EVENT_EVENT_TYPES_H
+#define MXPHYS_EVENT_EVENT_TYPES_H
+
+#include <cstdint>
+
+namespace mxphys::event {
+    enum class event_type : uint64_t {
+        COLLISION
+    };
+}
+
+#endif

--- a/include/mxphys/event/eventmanager.h
+++ b/include/mxphys/event/eventmanager.h
@@ -1,0 +1,33 @@
+#ifndef MXPHYS_EVENT_EVENTMANAGER_H
+#define MXPHYS_EVENT_EVENTMANAGER_H
+
+#include <unordered_map>
+#include <vector>
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include "event_types.h"
+#include "event_data.h"
+
+namespace mxphys::event {
+
+class eventmanager {
+private:
+    typedef std::function<void(std::unique_ptr<event_data> const&)> event_listener;
+    std::unordered_map<event_type, std::vector<event_listener>> m_registered_listeners;
+    std::unordered_map<event_type, std::vector<std::unique_ptr<event_data>>> m_eventdata;
+public:
+    
+    void add_event(event_type etype, std::unique_ptr<event_data>&& edata);
+    void emit_all();
+    void register_listener(event_type etype, const event_listener& listener);
+};
+
+}
+
+
+
+
+#endif
+

--- a/include/mxphys/forces.h
+++ b/include/mxphys/forces.h
@@ -3,9 +3,10 @@
 
 #include <functional>
 #include <vector>
+#include <optional>
+#include <utility>
 
 #include "types.h"
-
 
 namespace mxphys {
 
@@ -21,19 +22,14 @@ struct contact_point {
     vec2 normal;
     body* body1;
     body* body2;
-    std::vector<std::function<void(contact_point*)>> pre_collision_callbacks;
-    std::vector<std::function<void(contact_point*)>> post_collision_callbacks;
     bool resolve();
+    bool resolve(event::eventmanager& event_manager);
     contact_point() = delete;
     
     contact_point(vec2 _pos, vec2 _normal, body* _body1, body* _body2) :
         position(_pos), normal(_normal), body1(_body1), body2(_body2) {}
-    
-    contact_point(vec2 _pos, vec2 _normal, body* _body1, body* _body2,
-        std::initializer_list<std::function<void(contact_point*)>> _pre_callbacks,
-        std::initializer_list<std::function<void(contact_point*)>> _post_callbacks) :
-        position(_pos), normal(_normal), body1(_body1), body2(_body2),
-        pre_collision_callbacks(_pre_callbacks), post_collision_callbacks(_post_callbacks) {}
+private:
+    std::optional<impulse_point> calculate_impulse_point();
 };
 
 }

--- a/include/mxphys/types.h
+++ b/include/mxphys/types.h
@@ -11,6 +11,9 @@ class body;
 class convex_polygon;
 struct contact_point;
 struct impulse_point;
+namespace event {
+    class eventmanager;
+}
 
 struct vec2 {
     double x;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(MxPhysLib
     forces.cpp
     polygon.cpp
     body.cpp
+    eventmanager.cpp
 )
 
 target_compile_features(MxPhysLib PUBLIC cxx_std_20)
@@ -13,4 +14,4 @@ target_compile_features(MxPhysLib PUBLIC cxx_std_20)
 set_property(GLOBAL PROPERTY CXX_STANDARD_REQUIRED 20)
 set_property(GLOBAL PROPERTY CXX_STANDARD 20)
 
-SET(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -g")
+SET(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror -O3")

--- a/src/body.cpp
+++ b/src/body.cpp
@@ -21,29 +21,13 @@ void body::get_contact_points(body& other, std::vector<contact_point>& out_conta
     }
 }
 
-void body::get_contact_points(body& other, std::vector<contact_point>& out_contact_points,
-                              std::initializer_list<std::function<void(contact_point*)>> precallbacks,
-                              std::initializer_list<std::function<void(contact_point*)>> postcallbacks) {
-    for (auto p : shape.getPoints()) {
-        auto ptrue = position(p);
-        auto pomap = other.position.inverse()(ptrue);
-        auto normal = other.position.scale * other.shape.normalAt(pomap);
-        if (normal == vec2{0.0, 0.0}) continue;
-        out_contact_points.emplace_back(ptrue, normal, this, &other, precallbacks, postcallbacks);
-    }
-    for (auto q : other.shape.getPoints()) {
-        auto qtrue = other.position(q);
-        auto qimap = position.inverse()(qtrue);
-        auto normal = position.scale * shape.normalAt(qimap);
-        if (normal == vec2{0.0, 0.0}) continue;
-        out_contact_points.emplace_back(qtrue, normal, &other, this, precallbacks, postcallbacks);
-    }
+void body::apply_impulse(impulse_point imp) {
+    auto adj_origin = position.inverse()(imp.origin);
+    auto adj_impulse = position.scale.inverse() * imp.impulse;
+    angular_frequency += (1.0/moment_of_inertia) * adj_impulse.cross(-adj_origin);
+    velocity += (1.0/mass) * imp.impulse;
 }
 
-void body::apply_impulse(impulse_point imp) {
-        auto adj_origin = position.inverse()(imp.origin);
-        auto adj_impulse = position.scale.inverse() * imp.impulse;
-        angular_frequency += (1.0/moment_of_inertia) * adj_impulse.cross(-adj_origin);
-        velocity += (1.0/mass) * imp.impulse;
-    }
+uint64_t body::id_next = 0;
+    
 }

--- a/src/eventmanager.cpp
+++ b/src/eventmanager.cpp
@@ -1,0 +1,34 @@
+
+#include "mxphys/event/eventmanager.h"
+
+namespace mxphys::event {
+
+void eventmanager::add_event(event_type etype, std::unique_ptr<event_data>&& edata) {
+    auto it = m_eventdata.find(etype);
+    if (it == m_eventdata.end()) {
+        it = m_eventdata.emplace(etype, std::vector<std::unique_ptr<event_data>>()).first;
+    }
+    it->second.emplace_back(std::move(edata));
+}
+void eventmanager::emit_all() {
+    for(auto& [etype, listeners] : m_registered_listeners) {
+        auto data_it = m_eventdata.find(etype);
+        if (data_it == m_eventdata.end()) continue;
+        auto const& data_vec = data_it->second;
+        for (auto& listener : listeners) {
+            for (auto const& edata : data_vec) {
+                listener(edata);
+            }
+        }
+    }
+    m_eventdata.clear();
+}
+void eventmanager::register_listener(event_type etype, const event_listener& listener) {
+    auto it = m_registered_listeners.find(etype);
+    if (it == m_registered_listeners.end()) {
+        it = m_registered_listeners.emplace(etype, std::vector<event_listener>()).first;
+    }
+    it->second.emplace_back(listener);
+}
+
+}

--- a/src/polygon.cpp
+++ b/src/polygon.cpp
@@ -24,27 +24,31 @@ void convex_polygon::convexify() {
     };
     auto part = std::stable_partition(points.begin(), points.end(), above_line);
     auto l_end = part;
-    for (auto it = points.begin() + 2; it < l_end; ++it) {
-        while (it >= points.begin() + 2) {
-            auto const& v1 = *(it-2);
-            auto const& v2 = *(it-1);
-            auto const& v3 = *it;
-            if (gradient(v1, v2) < gradient(v1, v3)) break;
-            --it;
-            std::rotate(it, it+1, l_end);
-             --l_end;
+    if (std::distance(points.begin(), l_end) > 2) {
+        for (auto it = points.begin() + 2; it < l_end; ++it) {
+            while (it >= points.begin() + 2) {
+                auto const& v1 = *(it-2);
+                auto const& v2 = *(it-1);
+                auto const& v3 = *it;
+                if (gradient(v1, v2) < gradient(v1, v3)) break;
+                --it;
+                std::rotate(it, it+1, l_end);
+                 --l_end;
+            }
         }
     }
     auto u_end = points.end();
-    for (auto it = part + 2; it < u_end; ++it) {
-        while (it >= part + 2) {
-            auto const& v1 = *(it-2);
-            auto const& v2 = *(it-1);
-            auto const& v3 = *it;
-            if ((v1.x == v2.x) | (gradient(v1, v2) > gradient(v1, v3))) break;
-            --it;
-            std::rotate(it, it+1, u_end);
-            --u_end;
+    if (std::distance(part, u_end) > 2){ 
+        for (auto it = part + 2; it < u_end; ++it) {
+            while (it >= part + 2) {
+                auto const& v1 = *(it-2);
+                auto const& v2 = *(it-1);
+                auto const& v3 = *it;
+                if ((v1.x == v2.x) | ((gradient(v1, v2) > gradient(v1, v3)))) break;
+                --it;
+                std::rotate(it, it+1, u_end);
+                --u_end;
+            }
         }
     }
     auto end = l_end;


### PR DESCRIPTION
Replaced the convoluted callback system for collision handling to an event-driven system. Can now call `resolve()` on `contact_points` passing a reference to an `eventmanager` instance as a parameter, which keeps track of said events and can be told to `emit_all()` to any registered listeners. Also updated the collision test framework to use this. Notable performance improvement.